### PR TITLE
エラーページルータの作成

### DIFF
--- a/src/components/pages/UserProfile.tsx
+++ b/src/components/pages/UserProfile.tsx
@@ -1,15 +1,16 @@
 import { Container, Stack, } from '@mui/material'
 import { useEffect, useState } from 'react'
-import { useParams, Navigate } from 'react-router-dom';
+import { useParams } from 'react-router-dom';
 import { ResponseUser, UserApi } from '../../api/generated/api';
 import FriendList from '../model/FriendList';
 import GameResult from '../model/GameResult';
 import UserCard from '../model/UserCard';
+import ErrorRouter from '../ui/ErrorRouter';
 
 const UserProfile = () => {
   const [user, setUser] = useState<ResponseUser|null>(null)
-  const [error, setError] = useState<string|null>(null)
   const [isOwner, setIsOwner] = useState<boolean>(false)
+  const [statusCode, setStatusCode] = useState<number>(0)
   const userApi = new UserApi()
   const username = useParams().username
 
@@ -18,14 +19,14 @@ const UserProfile = () => {
       await userApi.getMe().then((res) => {
         setUser(res.data)
       }).catch((err) => {
-        setError(err.message)
+        setStatusCode(err.response.status)
       })
       if (username) {
         await userApi.getUsersUsername(username).then((res) => {
           setUser(res.data)
           setIsOwner(res.data.id === user?.id)
         }).catch((err) => {
-          setError(err.message)
+          setStatusCode(err.response.status)
         })
       } else {
         setIsOwner(true)
@@ -35,17 +36,19 @@ const UserProfile = () => {
   }, [])
 
   return (
-    <Container>
-      <Stack direction='row' margin={2} spacing={2}>
-        <Stack direction='column' spacing={2}>
-          { !error ? <UserCard user={user} isOwner={isOwner}/> : <Navigate to="404"/> }
-          <FriendList />
+    <ErrorRouter statusCode={statusCode}>
+      <Container>
+        <Stack direction='row' margin={2} spacing={2}>
+          <Stack direction='column' spacing={2}>
+            <UserCard user={user} isOwner={isOwner} />
+            <FriendList />
+          </Stack>
+          <Stack spacing={2}>
+            <GameResult/>
+          </Stack>
         </Stack>
-        <Stack spacing={2}>
-          <GameResult/>
-        </Stack>
-      </Stack>
-    </Container>
+      </Container>
+    </ErrorRouter>
   )
 }
 

--- a/src/components/ui/ErrorRouter.tsx
+++ b/src/components/ui/ErrorRouter.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from 'react'
+import { Navigate } from 'react-router-dom';
+
+type Props = {
+  statusCode: number
+  children: ReactNode
+}
+
+const ErrorRouter: React.VFC<Props> = ({ statusCode, children }) => {
+  switch (statusCode) {
+    case 0:
+      return <>{children}</>;
+    case 404:
+      return <Navigate to="/404" />;
+    case 500:
+      return <Navigate to="/500" />;
+    default:
+      return <div>Unknown Status Code: {statusCode}</div>
+  }
+}
+
+export default ErrorRouter


### PR DESCRIPTION
## チケットへのリンク
https://github.com/RIFT-tokyo/transcendence-front/issues/15
## やったこと
apiのレスポンスステータスをもとにエラーページに適宜遷移するコンポーネントの作成
使用例として、UserProfileで使用
## やらないこと

## テスト
1. このテストではモックサーバは立てず、apiを叩くようにしてください。（401のエラーを取得するため）
2. `/home`にアクセスすると認証が取れていないため、401のエラーページに遷移する

現状用意しているエラーページが404, 500だけなので、それ以外のエラーページの場合はステータスコードが出るだけです。
## その他
