### PR TITLE
/homeを認証ユーザ表示にする

### DIFF
--- a/src/components/model/UserCard.tsx
+++ b/src/components/model/UserCard.tsx
@@ -1,7 +1,7 @@
 import { Avatar, Button, Card, CardContent, Typography } from '@mui/material'
 import { ResponseUser } from '../../api/generated/api';
 
-const UserCard: React.VFC<{user: ResponseUser | null}> = ({user}) => {
+const UserCard: React.VFC<{user: ResponseUser | null, isOwner: boolean}> = ({user, isOwner}) => {
   return (
     <Card
       sx={{
@@ -12,7 +12,7 @@ const UserCard: React.VFC<{user: ResponseUser | null}> = ({user}) => {
         <Avatar sx={{ width: 296, height: 296 }} src={user?.profile_image}/>
         <Typography sx={{fontWeight: "bold"}} variant="h4">{user?.display_name ?? user?.username}</Typography>
         <Typography variant="subtitle1">{user?.username}</Typography>
-        <Button sx={{ width: 296, height: 30 }} color='inherit' variant='contained'>Edit Profile</Button>
+        <Button sx={{ width: 296, height: 30 }} color='inherit' variant='contained'>{isOwner ? "Edit Profile" : "Follow"}</Button>
         <Typography variant="body2">{user?.status_message}</Typography>
       </CardContent>
     </Card>

--- a/src/components/pages/UserProfile.tsx
+++ b/src/components/pages/UserProfile.tsx
@@ -35,7 +35,7 @@ const UserProfile = () => {
     <Container>
       <Stack direction='row' margin={2} spacing={2}>
         <Stack direction='column' spacing={2}>
-          { !error ? <UserCard user={user}/> : <Navigate to="404"/> }
+          { !error ? <UserCard user={user} isOwner={!!!username}/> : <Navigate to="404"/> }
           <FriendList />
         </Stack>
         <Stack spacing={2}>

--- a/src/components/pages/UserProfile.tsx
+++ b/src/components/pages/UserProfile.tsx
@@ -9,6 +9,7 @@ import UserCard from '../model/UserCard';
 const UserProfile = () => {
   const [user, setUser] = useState<ResponseUser|null>(null)
   const [error, setError] = useState<string|null>(null)
+  const [isOwner, setIsOwner] = useState<boolean>(false)
   const userApi = new UserApi()
   const username = useParams().username
 
@@ -35,7 +36,7 @@ const UserProfile = () => {
     <Container>
       <Stack direction='row' margin={2} spacing={2}>
         <Stack direction='column' spacing={2}>
-          { !error ? <UserCard user={user} isOwner={!!!username}/> : <Navigate to="404"/> }
+          { !error ? <UserCard user={user} isOwner={isOwner}/> : <Navigate to="404"/> }
           <FriendList />
         </Stack>
         <Stack spacing={2}>

--- a/src/components/pages/UserProfile.tsx
+++ b/src/components/pages/UserProfile.tsx
@@ -15,18 +15,20 @@ const UserProfile = () => {
 
   useEffect(() => {
     (async () => {
+      await userApi.getMe().then((res) => {
+        setUser(res.data)
+      }).catch((err) => {
+        setError(err.message)
+      })
       if (username) {
         await userApi.getUsersUsername(username).then((res) => {
           setUser(res.data)
+          setIsOwner(res.data.id === user?.id)
         }).catch((err) => {
           setError(err.message)
         })
       } else {
-        await userApi.getMe().then((res) => {
-          setUser(res.data)
-        }).catch((err) => {
-          setError(err.message)
-        })
+        setIsOwner(true)
       }
     })()
   // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/components/pages/UserProfile.tsx
+++ b/src/components/pages/UserProfile.tsx
@@ -21,9 +21,7 @@ const UserProfile = () => {
           setError(err.message)
         })
       } else {
-        // 本当はここでログインユーザー情報を取得する
-        // await userApi.getMe().then((res) => {
-        await userApi.getUsersUserId(1).then((res) => {
+        await userApi.getMe().then((res) => {
           setUser(res.data)
         }).catch((err) => {
           setError(err.message)


### PR DESCRIPTION
## チケットへのリンク

#14

## やったこと

- `/home` で `GET /me` を叩くようにしました。
- `/home` か `/users/:username` かによって、Profileのボタンのテキストを切り替えるようにしました。
  - `/home` ："Edit profile"
  - `/users/:username` ："Follow"

## やらないこと

Follow, Unfollowは区別せずFollowとしています。

## テスト

1. Stoplight Studioを起動し、Security Schemesを削除してMockサーバを立ち上げる
1. `src/api/generated/base.ts` の `BASE_PATH` を `http://localhost:4211` から `http://localhost:3100` に変更する
1. ブラウザのデベロッパーツールを開き、ネットワークタブを選択する
1. `http://localhost:4212/` にアクセス
   - `http://localhost:3100/me` にリクエストが飛んでいることを確認
   - ボタンのテキストが "EDIT PROFILE" であることを確認
1. `http://localhost:4212/users/aa` (aaは任意の文字列)
   - `http://localhost:3100/users/by/aa` にリクエストが飛んでいることを確認
   - ボタンのテキストが "FOLLOW" であることを確認

## その他

以下、より良い書き方があるか気になっている箇所です。

- `UserCard.tsx` の `isOwner` という命名は適切か。
- `UserProfile.tsx` の `!!!username` が理解できるか。

