### PR TITLE
ログアウト機能の追加

### DIFF
--- a/src/api/generated/.openapi-generator/FILES
+++ b/src/api/generated/.openapi-generator/FILES
@@ -1,5 +1,6 @@
 .gitignore
 .npmignore
+.openapi-generator-ignore
 api.ts
 base.ts
 common.ts

--- a/src/api/generated/api.ts
+++ b/src/api/generated/api.ts
@@ -176,7 +176,7 @@ export const AuthApiAxiosParamCreator = function (configuration?: Configuration)
         },
         /**
          * The first client request by 42 for oauth2.0. After this, you will be redirected to 42\'s confirm browser.
-         * @summary Oauth login request
+         * @summary Login with 42 intra account
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -206,7 +206,7 @@ export const AuthApiAxiosParamCreator = function (configuration?: Configuration)
         },
         /**
          * username and password auth without using auth.
-         * @summary username and password login
+         * @summary Login with username and password
          * @param {Login} [login] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
@@ -232,6 +232,38 @@ export const AuthApiAxiosParamCreator = function (configuration?: Configuration)
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(login, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * logout from transcendence
+         * @summary Logout from transcendence
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        postAuthLogout: async (options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/auth/logout`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication sessionAuth required
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -294,7 +326,7 @@ export const AuthApiFp = function(configuration?: Configuration) {
         },
         /**
          * The first client request by 42 for oauth2.0. After this, you will be redirected to 42\'s confirm browser.
-         * @summary Oauth login request
+         * @summary Login with 42 intra account
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -304,13 +336,23 @@ export const AuthApiFp = function(configuration?: Configuration) {
         },
         /**
          * username and password auth without using auth.
-         * @summary username and password login
+         * @summary Login with username and password
          * @param {Login} [login] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         async postAuthLogin(login?: Login, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.postAuthLogin(login, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * logout from transcendence
+         * @summary Logout from transcendence
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async postAuthLogout(options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.postAuthLogout(options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
         /**
@@ -345,7 +387,7 @@ export const AuthApiFactory = function (configuration?: Configuration, basePath?
         },
         /**
          * The first client request by 42 for oauth2.0. After this, you will be redirected to 42\'s confirm browser.
-         * @summary Oauth login request
+         * @summary Login with 42 intra account
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
@@ -354,13 +396,22 @@ export const AuthApiFactory = function (configuration?: Configuration, basePath?
         },
         /**
          * username and password auth without using auth.
-         * @summary username and password login
+         * @summary Login with username and password
          * @param {Login} [login] 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
         postAuthLogin(login?: Login, options?: any): AxiosPromise<void> {
             return localVarFp.postAuthLogin(login, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * logout from transcendence
+         * @summary Logout from transcendence
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        postAuthLogout(options?: any): AxiosPromise<void> {
+            return localVarFp.postAuthLogout(options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -392,7 +443,7 @@ export interface AuthApiInterface {
 
     /**
      * The first client request by 42 for oauth2.0. After this, you will be redirected to 42\'s confirm browser.
-     * @summary Oauth login request
+     * @summary Login with 42 intra account
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AuthApiInterface
@@ -401,13 +452,22 @@ export interface AuthApiInterface {
 
     /**
      * username and password auth without using auth.
-     * @summary username and password login
+     * @summary Login with username and password
      * @param {Login} [login] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AuthApiInterface
      */
     postAuthLogin(login?: Login, options?: AxiosRequestConfig): AxiosPromise<void>;
+
+    /**
+     * logout from transcendence
+     * @summary Logout from transcendence
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AuthApiInterface
+     */
+    postAuthLogout(options?: AxiosRequestConfig): AxiosPromise<void>;
 
     /**
      * 
@@ -441,7 +501,7 @@ export class AuthApi extends BaseAPI implements AuthApiInterface {
 
     /**
      * The first client request by 42 for oauth2.0. After this, you will be redirected to 42\'s confirm browser.
-     * @summary Oauth login request
+     * @summary Login with 42 intra account
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
      * @memberof AuthApi
@@ -452,7 +512,7 @@ export class AuthApi extends BaseAPI implements AuthApiInterface {
 
     /**
      * username and password auth without using auth.
-     * @summary username and password login
+     * @summary Login with username and password
      * @param {Login} [login] 
      * @param {*} [options] Override http request option.
      * @throws {RequiredError}
@@ -460,6 +520,17 @@ export class AuthApi extends BaseAPI implements AuthApiInterface {
      */
     public postAuthLogin(login?: Login, options?: AxiosRequestConfig) {
         return AuthApiFp(this.configuration).postAuthLogin(login, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * logout from transcendence
+     * @summary Logout from transcendence
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AuthApi
+     */
+    public postAuthLogout(options?: AxiosRequestConfig) {
+        return AuthApiFp(this.configuration).postAuthLogout(options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/src/components/ui/AppBarWithMenu.tsx
+++ b/src/components/ui/AppBarWithMenu.tsx
@@ -3,11 +3,14 @@ import MenuIcon from '@mui/icons-material/Menu';
 import { AccountCircle } from '@mui/icons-material';
 import { useState } from 'react';
 import { Outlet } from 'react-router-dom';
-import { NavLink } from 'react-router-dom';
+import { useNavigate } from 'react-router-dom';
+import { AuthApi } from '../../api/generated/api';
 
 const AppBarWithMenu = () => {
   const [auth] = useState(true);
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const navigate = useNavigate();
+  const authApi = new AuthApi();
 
   const handleMenu = (event: React.MouseEvent<HTMLElement>) => {
     setAnchorEl(event.currentTarget);
@@ -16,6 +19,28 @@ const AppBarWithMenu = () => {
   const handleClose = () => {
     setAnchorEl(null);
   };
+
+  const goHome = () => {
+    handleClose();
+    navigate('/');
+  };
+
+  const goToSettings = () => {
+    handleClose();
+    navigate('/settings');
+  };
+
+  const logout = async () => {
+    handleClose();
+    await authApi
+      .postAuthLogout({ withCredentials: true })
+      .then(() => {
+        goHome();
+      })
+      .catch((err) => {
+        console.log(err);
+      })
+  }
 
   return (
     <div>
@@ -61,17 +86,13 @@ const AppBarWithMenu = () => {
                   open={Boolean(anchorEl)}
                   onClose={handleClose}
                 >
-                  <MenuItem onClick={handleClose}>
-                    <Link component={NavLink} color='inherit' underline='none' to='/home'>
-                      Profile
-                    </Link>
+                  <MenuItem onClick={goHome}>
+                    Profile
                   </MenuItem>
-                  <MenuItem onClick={handleClose}>
-                    <Link component={NavLink} color='inherit' underline='none' to='/settings'>
-                      Settings
-                    </Link>
+                  <MenuItem onClick={goToSettings}>
+                    Settings
                   </MenuItem>
-                  <MenuItem onClick={handleClose}>
+                  <MenuItem onClick={logout}>
                     Logout
                   </MenuItem>
                 </Menu>


### PR DESCRIPTION
## チケットへのリンク
https://github.com/RIFT-tokyo/transcendence-front/issues/26
## やったこと
ログアウト機能をフロントに実装しました。
apiのPRと合わせて確認してください。
https://github.com/RIFT-tokyo/transcendence-api/pull/37
## やらないこと

## テスト
1. apiのブランチを合わせる(https://github.com/RIFT-tokyo/transcendence-api/pull/37)
2. 方法はなんでもいいので、ログインする
3. 好きなページでAppBarの右端のアイコンをクリックする
4. ログアウトをクリックしてサインインの画面に戻ることを確認する
## その他
