### PR TITLE
設定画面のアカウント情報更新バグの修正

### DIFF
--- a/src/components/pages/Settings.tsx
+++ b/src/components/pages/Settings.tsx
@@ -53,8 +53,9 @@ const Settings: React.VFC<Props> = ({ active }) => {
     }
     setLoading(true);
     const data = {
-      ...user,
-      profile_image: undefined,
+      username: user.username,
+      display_name: user.display_name,
+      status_message: user.status_message,
     };
     await userApi
       .putUsersUserId(user.id!, data, { withCredentials: true })


### PR DESCRIPTION
## チケットへのリンク
https://github.com/RIFT-tokyo/transcendence-front/issues/28
## やったこと
設定画面からユーザー情報が変更できないバグを修正しました。

## やらないこと

## テスト
1. アカウントの設定画面に移動
2. フォームを書き換えて、SAVEボタンをクリック
3. 正しいレスポンスが返ってきて、プロフィールページに表示される内容が修正されていることを確認する
## その他
