### PR TITLE
apiの.prettierrcを使用するように

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,4 @@
+{
+  "singleQuote": true,
+  "trailingComma": "all"
+}

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,0 @@
-module.exports = {
-  printWidth: 100,
-  singleQuote: true,
-  semi: true,
-}


### PR DESCRIPTION
## チケットへのリンク
fix #36 

## やったこと
api側の.prettierrcをコピーし、front側の .prettierrc.js を削除しました。

## やらないこと
実際のformatは行っていません。

## テスト
特になし。

## その他
特になし。
