### PR TITLE
画像変更機能の追加

### DIFF
--- a/src/api/generated/.openapi-generator/FILES
+++ b/src/api/generated/.openapi-generator/FILES
@@ -1,6 +1,5 @@
 .gitignore
 .npmignore
-.openapi-generator-ignore
 api.ts
 base.ts
 common.ts

--- a/src/api/generated/api.ts
+++ b/src/api/generated/api.ts
@@ -24,6 +24,19 @@ import { BASE_PATH, COLLECTION_FORMATS, RequestArgs, BaseAPI, RequiredError } fr
 /**
  * 
  * @export
+ * @interface FilePath
+ */
+export interface FilePath {
+    /**
+     * 
+     * @type {string}
+     * @memberof FilePath
+     */
+    'file_path'?: string;
+}
+/**
+ * 
+ * @export
  * @interface Login
  */
 export interface Login {
@@ -1415,7 +1428,7 @@ export const UserApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async postUsersUserIDImages(userID: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+        async postUsersUserIDImages(userID: number, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FilePath>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.postUsersUserIDImages(userID, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
@@ -1508,7 +1521,7 @@ export const UserApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        postUsersUserIDImages(userID: number, options?: any): AxiosPromise<void> {
+        postUsersUserIDImages(userID: number, options?: any): AxiosPromise<FilePath> {
             return localVarFp.postUsersUserIDImages(userID, options).then((request) => request(axios, basePath));
         },
         /**
@@ -1599,7 +1612,7 @@ export interface UserApiInterface {
      * @throws {RequiredError}
      * @memberof UserApiInterface
      */
-    postUsersUserIDImages(userID: number, options?: AxiosRequestConfig): AxiosPromise<void>;
+    postUsersUserIDImages(userID: number, options?: AxiosRequestConfig): AxiosPromise<FilePath>;
 
     /**
      * 

--- a/src/api/upload/fileUpload.ts
+++ b/src/api/upload/fileUpload.ts
@@ -1,93 +1,112 @@
-import globalAxios, { AxiosInstance, AxiosPromise, AxiosRequestConfig } from 'axios';
+import globalAxios, {
+  AxiosInstance,
+  AxiosPromise,
+  AxiosRequestConfig,
+} from 'axios';
 import { Configuration, FilePath } from '../generated';
 import { BaseAPI, BASE_PATH, RequestArgs } from '../generated/base';
-import { assertParamExists, createRequestFunction, DUMMY_BASE_URL, setSearchParams, toPathString } from '../generated/common';
+import {
+  assertParamExists,
+  createRequestFunction,
+  DUMMY_BASE_URL,
+  setSearchParams,
+  toPathString,
+} from '../generated/common';
 
-/**
- * UserApi - axios parameter creator
- * @export
- */
-export const FileUploadApiAxiosParamCreator = (configuration?: Configuration) => ({
-        /**
-         *
-         * @summary Upload a user profile image
-         * @param {number} userID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        postUsersUserIDImages: async (userID: number, file: File, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
-            // verify required parameter 'userID' is not null or undefined
-            assertParamExists('postUsersUserIDImages', 'userID', userID)
-            const localVarPath = `/users/{userID}/images`
-                .replace(`{${"userID"}}`, encodeURIComponent(String(userID)));
-            // use dummy base URL string because the URL constructor only accepts absolute URLs.
-            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
-            let baseOptions;
-            if (configuration) {
-                baseOptions = configuration.baseOptions;
-            }
+export const FileUploadApiAxiosParamCreator = (
+  configuration?: Configuration,
+) => ({
+  postUsersUserIDImages: async (
+    userID: number,
+    file: File,
+    options: AxiosRequestConfig = {},
+  ): Promise<RequestArgs> => {
+    // verify required parameter 'userID' is not null or undefined
+    assertParamExists('postUsersUserIDImages', 'userID', userID);
+    const localVarPath = `/users/{userID}/images`.replace(
+      `{${'userID'}}`,
+      encodeURIComponent(String(userID)),
+    );
+    // use dummy base URL string because the URL constructor only accepts absolute URLs.
+    const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+    let baseOptions;
+    if (configuration) {
+      baseOptions = configuration.baseOptions;
+    }
 
-            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
-            const localVarHeaderParameter = {} as any;
-            const localVarQueryParameter = {} as any;
+    const localVarRequestOptions = {
+      method: 'POST',
+      ...baseOptions,
+      ...options,
+    };
+    const localVarHeaderParameter = {} as any;
+    const localVarQueryParameter = {} as any;
 
-            localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+    localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
 
-            const data = new FormData();
-            data.append('file', file);
+    const data = new FormData();
+    data.append('file', file);
 
-            setSearchParams(localVarUrlObj, localVarQueryParameter);
-            const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
-            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = data;
+    setSearchParams(localVarUrlObj, localVarQueryParameter);
+    const headersFromBaseOptions =
+      baseOptions && baseOptions.headers ? baseOptions.headers : {};
+    localVarRequestOptions.headers = {
+      ...localVarHeaderParameter,
+      ...headersFromBaseOptions,
+      ...options.headers,
+    };
+    localVarRequestOptions.data = data;
 
-            return {
-                url: toPathString(localVarUrlObj),
-                options: localVarRequestOptions,
-            };
-        },
-    })
+    return {
+      url: toPathString(localVarUrlObj),
+      options: localVarRequestOptions,
+    };
+  },
+});
 
 export const FileUploadApiFp = (configuration?: Configuration) => {
-    const localVarAxiosParamCreator = FileUploadApiAxiosParamCreator(configuration);
-    return {
-        /**
-         *
-         * @summary Upload a user profile image
-         * @param {number} userID
-         * @param {*} [options] Override http request option.
-         * @throws {RequiredError}
-         */
-        async postUsersUserIDImages(userID: number, file: File, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FilePath>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.postUsersUserIDImages(userID, file, options);
-            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
-        },
-    }
-}
+  const localVarAxiosParamCreator =
+    FileUploadApiAxiosParamCreator(configuration);
+  return {
+    async postUsersUserIDImages(
+      userID: number,
+      file: File,
+      options?: AxiosRequestConfig,
+    ): Promise<
+      (axios?: AxiosInstance, basePath?: string) => AxiosPromise<FilePath>
+    > {
+      const localVarAxiosArgs =
+        await localVarAxiosParamCreator.postUsersUserIDImages(
+          userID,
+          file,
+          options,
+        );
+      return createRequestFunction(
+        localVarAxiosArgs,
+        globalAxios,
+        BASE_PATH,
+        configuration,
+      );
+    },
+  };
+};
 
 export interface FileUploadApiInterface {
-    /**
-     *
-     * @summary Upload a user profile image
-     * @param {number} userID
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof UserApiInterface
-     */
-     postUsersUserIDImages(userID: number, file: File, options?: AxiosRequestConfig): AxiosPromise<FilePath>;
+  postUsersUserIDImages(
+    userID: number,
+    file: File,
+    options?: AxiosRequestConfig,
+  ): AxiosPromise<FilePath>;
 }
 
 export class FileUploadApi extends BaseAPI implements FileUploadApiInterface {
-    /**
-     *
-     * @summary Upload a user profile image
-     * @param {number} userID
-     * @param {file} any
-     * @param {*} [options] Override http request option.
-     * @throws {RequiredError}
-     * @memberof UserApi
-     */
-    public postUsersUserIDImages(userID: number, file: File, options?: AxiosRequestConfig) {
-        return FileUploadApiFp(this.configuration).postUsersUserIDImages(userID, file, options).then((request) => request(this.axios, this.basePath));
-    }
+  public postUsersUserIDImages(
+    userID: number,
+    file: File,
+    options?: AxiosRequestConfig,
+  ) {
+    return FileUploadApiFp(this.configuration)
+      .postUsersUserIDImages(userID, file, options)
+      .then((request) => request(this.axios, this.basePath));
+  }
 }

--- a/src/api/upload/fileUpload.ts
+++ b/src/api/upload/fileUpload.ts
@@ -1,0 +1,93 @@
+import globalAxios, { AxiosInstance, AxiosPromise, AxiosRequestConfig } from 'axios';
+import { Configuration, FilePath } from '../generated';
+import { BaseAPI, BASE_PATH, RequestArgs } from '../generated/base';
+import { assertParamExists, createRequestFunction, DUMMY_BASE_URL, setSearchParams, toPathString } from '../generated/common';
+
+/**
+ * UserApi - axios parameter creator
+ * @export
+ */
+export const FileUploadApiAxiosParamCreator = (configuration?: Configuration) => ({
+        /**
+         *
+         * @summary Upload a user profile image
+         * @param {number} userID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        postUsersUserIDImages: async (userID: number, file: File, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'userID' is not null or undefined
+            assertParamExists('postUsersUserIDImages', 'userID', userID)
+            const localVarPath = `/users/{userID}/images`
+                .replace(`{${"userID"}}`, encodeURIComponent(String(userID)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'POST', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            localVarHeaderParameter['Content-Type'] = 'multipart/form-data';
+
+            const data = new FormData();
+            data.append('file', file);
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            const headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = data;
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+    })
+
+export const FileUploadApiFp = (configuration?: Configuration) => {
+    const localVarAxiosParamCreator = FileUploadApiAxiosParamCreator(configuration);
+    return {
+        /**
+         *
+         * @summary Upload a user profile image
+         * @param {number} userID
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async postUsersUserIDImages(userID: number, file: File, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<FilePath>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.postUsersUserIDImages(userID, file, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+    }
+}
+
+export interface FileUploadApiInterface {
+    /**
+     *
+     * @summary Upload a user profile image
+     * @param {number} userID
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UserApiInterface
+     */
+     postUsersUserIDImages(userID: number, file: File, options?: AxiosRequestConfig): AxiosPromise<FilePath>;
+}
+
+export class FileUploadApi extends BaseAPI implements FileUploadApiInterface {
+    /**
+     *
+     * @summary Upload a user profile image
+     * @param {number} userID
+     * @param {file} any
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof UserApi
+     */
+    public postUsersUserIDImages(userID: number, file: File, options?: AxiosRequestConfig) {
+        return FileUploadApiFp(this.configuration).postUsersUserIDImages(userID, file, options).then((request) => request(this.axios, this.basePath));
+    }
+}

--- a/src/api/upload/index.ts
+++ b/src/api/upload/index.ts
@@ -1,1 +1,1 @@
-export * from "./fileUpload";
+export * from './fileUpload';

--- a/src/api/upload/index.ts
+++ b/src/api/upload/index.ts
@@ -1,0 +1,1 @@
+export * from "./fileUpload";

--- a/src/components/model/AccountSetting.tsx
+++ b/src/components/model/AccountSetting.tsx
@@ -1,47 +1,79 @@
-import { Avatar, Divider, Stack, TextField, Typography } from '@mui/material'
-import { User } from '../../api/generated/api'
+import { Divider, Stack, TextField, Typography } from '@mui/material';
+import { VFC, ChangeEvent } from 'react';
+import { User } from '../../api/generated/api';
+import { FileUploadApi } from '../../api/upload/fileUpload';
+import ImageForm from '../ui/ImageForm';
 
 type Props = {
-  user: User,
-  setUser: (user: User) => void
-}
+  user: User;
+  // eslint-disable-next-line no-unused-vars
+  setUser: (user: User) => void;
+};
 
-const AccountSetting: React.VFC<Props> = ({ user, setUser }) => {
-  const usernameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+const AccountSetting: VFC<Props> = ({ user, setUser }: Props) => {
+  const usernameChange = (e: ChangeEvent<HTMLInputElement>) => {
     setUser({
       ...user,
-      username: e.target.value
-    })
-  }
-  const displayNameChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      username: e.target.value,
+    });
+  };
+  const displayNameChange = (e: ChangeEvent<HTMLInputElement>) => {
     setUser({
       ...user,
-      display_name: e.target.value
-    })
-  }
-  const statusMessageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      display_name: e.target.value,
+    });
+  };
+  const statusMessageChange = (e: ChangeEvent<HTMLInputElement>) => {
     setUser({
       ...user,
-      status_message: e.target.value
-    })
+      status_message: e.target.value,
+    });
+  };
+  const saveImage = async (file: File) => {
+    if (!user.id) {
+      return;
+    }
+    const fileUploadApi = new FileUploadApi();
+    fileUploadApi.postUsersUserIDImages(user.id, file, { withCredentials: true }).then((res) => {
+      const newPath = res.data.file_path;
+      setUser({
+        ...user,
+        profile_image: newPath,
+      })
+    });
   }
 
   return (
-    <Stack bgcolor='background.paper' width={500}>
-      <Stack padding={2} direction='column' spacing={1}>
-        <Typography variant='h4'>Account</Typography>
+    <Stack bgcolor="background.paper" width={500}>
+      <Stack padding={2} direction="column" spacing={1}>
+        <Typography variant="h4">Account</Typography>
         <Divider />
-        <Typography variant='h6'>Profile Image</Typography>
-        <Avatar sx={{ width: 296, height: 296 }} src={user.profile_image}/>
-        <Typography variant='h6'>Username</Typography>
-        <TextField size='small' variant='outlined' value={user.username} onChange={usernameChange} />
-        <Typography variant='h6'>Display Name</Typography>
-        <TextField size='small' variant='outlined' value={user.display_name} onChange={displayNameChange} />
-        <Typography variant='h6'>Bio</Typography>
-        <TextField size='small' variant='outlined' value={user.status_message} onChange={statusMessageChange} />
+        <Typography variant="h6">Profile Image</Typography>
+        <ImageForm saveImage={saveImage} profileImageURL={user.profile_image} />
+        <Typography variant="h6">Username</Typography>
+        <TextField
+          size="small"
+          variant="outlined"
+          value={user.username}
+          onChange={usernameChange}
+        />
+        <Typography variant="h6">Display Name</Typography>
+        <TextField
+          size="small"
+          variant="outlined"
+          value={user.display_name}
+          onChange={displayNameChange}
+        />
+        <Typography variant="h6">Bio</Typography>
+        <TextField
+          size="small"
+          variant="outlined"
+          value={user.status_message}
+          onChange={statusMessageChange}
+        />
       </Stack>
     </Stack>
-  )
-}
+  );
+};
 
-export default AccountSetting
+export default AccountSetting;

--- a/src/components/model/AccountSetting.tsx
+++ b/src/components/model/AccountSetting.tsx
@@ -34,13 +34,15 @@ const AccountSetting: VFC<Props> = ({ user, setUser }: Props) => {
     if (!user.id) {
       return;
     }
-    fileUploadApi.postUsersUserIDImages(user.id, file, { withCredentials: true }).then((res) => {
-      setUser({
-        ...user,
-        profile_image: res.data.file_path,
-      })
-    });
-  }
+    fileUploadApi
+      .postUsersUserIDImages(user.id, file, { withCredentials: true })
+      .then((res) => {
+        setUser({
+          ...user,
+          profile_image: res.data.file_path,
+        });
+      });
+  };
 
   return (
     <Stack bgcolor="background.paper" width={500}>

--- a/src/components/model/AccountSetting.tsx
+++ b/src/components/model/AccountSetting.tsx
@@ -1,4 +1,4 @@
-import { Divider, Stack, TextField, Typography } from '@mui/material';
+import { Avatar, Divider, Stack, TextField, Typography } from '@mui/material';
 import { VFC, ChangeEvent } from 'react';
 import { User } from '../../api/generated/api';
 import { FileUploadApi } from '../../api/upload/fileUpload';
@@ -11,6 +11,7 @@ type Props = {
 };
 
 const AccountSetting: VFC<Props> = ({ user, setUser }: Props) => {
+  const fileUploadApi = new FileUploadApi();
   const usernameChange = (e: ChangeEvent<HTMLInputElement>) => {
     setUser({
       ...user,
@@ -33,12 +34,10 @@ const AccountSetting: VFC<Props> = ({ user, setUser }: Props) => {
     if (!user.id) {
       return;
     }
-    const fileUploadApi = new FileUploadApi();
     fileUploadApi.postUsersUserIDImages(user.id, file, { withCredentials: true }).then((res) => {
-      const newPath = res.data.file_path;
       setUser({
         ...user,
-        profile_image: newPath,
+        profile_image: res.data.file_path,
       })
     });
   }
@@ -49,7 +48,8 @@ const AccountSetting: VFC<Props> = ({ user, setUser }: Props) => {
         <Typography variant="h4">Account</Typography>
         <Divider />
         <Typography variant="h6">Profile Image</Typography>
-        <ImageForm saveImage={saveImage} profileImageURL={user.profile_image} />
+        <Avatar sx={{ width: 296, height: 296 }} src={user.profile_image} />
+        <ImageForm saveImage={saveImage} />
         <Typography variant="h6">Username</Typography>
         <TextField
           size="small"

--- a/src/components/ui/ImageForm.tsx
+++ b/src/components/ui/ImageForm.tsx
@@ -4,7 +4,7 @@ import { IconButton, Tooltip } from '@mui/material';
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
 
 interface Props {
-  saveImage: any // (fileName: Blob) => Promise<void> // callback taking a string and then dispatching a store actions
+  saveImage: any; // (fileName: Blob) => Promise<void> // callback taking a string and then dispatching a store actions
 }
 
 const ImageForm: VFC<Props> = ({ saveImage }: Props) => {
@@ -23,10 +23,7 @@ const ImageForm: VFC<Props> = ({ saveImage }: Props) => {
       />
       <Tooltip title="Select Image">
         <label htmlFor="profileImage">
-          <IconButton
-            aria-label="upload picture"
-            component="span"
-          >
+          <IconButton aria-label="upload picture" component="span">
             <PhotoCameraIcon fontSize="large" />
           </IconButton>
         </label>

--- a/src/components/ui/ImageForm.tsx
+++ b/src/components/ui/ImageForm.tsx
@@ -1,0 +1,40 @@
+/* eslint-disable jsx-a11y/label-has-associated-control */
+import { VFC } from 'react';
+import { Avatar, IconButton, Tooltip } from '@mui/material';
+import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
+
+interface Props {
+  saveImage: any // (fileName: Blob) => Promise<void> // callback taking a string and then dispatching a store actions
+  profileImageURL: string | undefined
+}
+
+const ImageForm: VFC<Props> = ({ saveImage, profileImageURL }: Props) => {
+  const handleCapture = ({ target }: any) => {
+    saveImage(target.files[0]);
+  };
+
+  return (
+    <>
+      <input
+        accept="image/jpeg, image/png, image/jpg, image/gif"
+        id="profileImage"
+        style={{ display: 'none' }}
+        type="file"
+        onChange={handleCapture}
+      />
+      <Avatar sx={{ width: 296, height: 296 }} src={profileImageURL} />
+        <Tooltip title="Select Image">
+          <label htmlFor="profileImage">
+            <IconButton
+              aria-label="upload picture"
+              component="span"
+            >
+              <PhotoCameraIcon fontSize="large" />
+            </IconButton>
+          </label>
+        </Tooltip>
+    </>
+  );
+};
+
+export default ImageForm;

--- a/src/components/ui/ImageForm.tsx
+++ b/src/components/ui/ImageForm.tsx
@@ -1,14 +1,13 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 import { VFC } from 'react';
-import { Avatar, IconButton, Tooltip } from '@mui/material';
+import { IconButton, Tooltip } from '@mui/material';
 import PhotoCameraIcon from '@mui/icons-material/PhotoCamera';
 
 interface Props {
   saveImage: any // (fileName: Blob) => Promise<void> // callback taking a string and then dispatching a store actions
-  profileImageURL: string | undefined
 }
 
-const ImageForm: VFC<Props> = ({ saveImage, profileImageURL }: Props) => {
+const ImageForm: VFC<Props> = ({ saveImage }: Props) => {
   const handleCapture = ({ target }: any) => {
     saveImage(target.files[0]);
   };
@@ -22,17 +21,16 @@ const ImageForm: VFC<Props> = ({ saveImage, profileImageURL }: Props) => {
         type="file"
         onChange={handleCapture}
       />
-      <Avatar sx={{ width: 296, height: 296 }} src={profileImageURL} />
-        <Tooltip title="Select Image">
-          <label htmlFor="profileImage">
-            <IconButton
-              aria-label="upload picture"
-              component="span"
-            >
-              <PhotoCameraIcon fontSize="large" />
-            </IconButton>
-          </label>
-        </Tooltip>
+      <Tooltip title="Select Image">
+        <label htmlFor="profileImage">
+          <IconButton
+            aria-label="upload picture"
+            component="span"
+          >
+            <PhotoCameraIcon fontSize="large" />
+          </IconButton>
+        </label>
+      </Tooltip>
     </>
   );
 };


### PR DESCRIPTION
## チケットへのリンク
fix #30
## やったこと
プロフィール画像の変更機能を追加しました。
api, docsも併せて変更してます。
## やらないこと

## テスト
1. 設定画面からカメラアイコンをクリックし、ファイルを選択する
2. プロフィール画像が更新されていることを確認する


同じ拡張子でも変更はされますが、Reactの中で再レンダリングしたところでファイルパスが変わらないので画像は変わりません。
ブラウザのリロードをしてください。
拡張子が変われば、画像のリクエストが飛ぶので勝手に変わってくれます。
s3に保存するファイル名を`{{id}}-profile.{{ext}}`にしているのを、uuidとか適当に振るようにするといいのかもしれない。
この辺はレビューで指摘があれば、api側で修正します。
## その他
