### PR TITLE
パスワード変更機能追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@types/react": "^17.0.38",
     "@types/react-dom": "^17.0.11",
     "axios": "^0.24.0",
+    "notistack": "^2.0.3",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^6.2.1",

--- a/src/api/generated/api.ts
+++ b/src/api/generated/api.ts
@@ -75,6 +75,25 @@ export interface ModelError {
 /**
  * 
  * @export
+ * @interface Password
+ */
+export interface Password {
+    /**
+     * 
+     * @type {string}
+     * @memberof Password
+     */
+    'old_password': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof Password
+     */
+    'new_password': string;
+}
+/**
+ * 
+ * @export
  * @interface User
  */
 export interface User {
@@ -290,7 +309,7 @@ export const AuthApiAxiosParamCreator = function (configuration?: Configuration)
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        postUsers: async (login?: Login, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+        postAuthSignup: async (login?: Login, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
             const localVarPath = `/auth/signup`;
             // use dummy base URL string because the URL constructor only accepts absolute URLs.
             const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
@@ -311,6 +330,42 @@ export const AuthApiAxiosParamCreator = function (configuration?: Configuration)
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
             localVarRequestOptions.data = serializeDataIfNeeded(login, localVarRequestOptions, configuration)
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Update User Password
+         * @param {Password} [password] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        putAuthPassword: async (password?: Password, options: AxiosRequestConfig = {}): Promise<RequestArgs> => {
+            const localVarPath = `/auth/password`;
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'PUT', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication sessionAuth required
+
+
+    
+            localVarHeaderParameter['Content-Type'] = 'application/json';
+
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+            localVarRequestOptions.data = serializeDataIfNeeded(password, localVarRequestOptions, configuration)
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -375,8 +430,19 @@ export const AuthApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async postUsers(login?: Login, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.postUsers(login, options);
+        async postAuthSignup(login?: Login, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.postAuthSignup(login, options);
+            return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
+        },
+        /**
+         * 
+         * @summary Update User Password
+         * @param {Password} [password] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async putAuthPassword(password?: Password, options?: AxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<void>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.putAuthPassword(password, options);
             return createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration);
         },
     }
@@ -433,8 +499,18 @@ export const AuthApiFactory = function (configuration?: Configuration, basePath?
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        postUsers(login?: Login, options?: any): AxiosPromise<void> {
-            return localVarFp.postUsers(login, options).then((request) => request(axios, basePath));
+        postAuthSignup(login?: Login, options?: any): AxiosPromise<void> {
+            return localVarFp.postAuthSignup(login, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Update User Password
+         * @param {Password} [password] 
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        putAuthPassword(password?: Password, options?: any): AxiosPromise<void> {
+            return localVarFp.putAuthPassword(password, options).then((request) => request(axios, basePath));
         },
     };
 };
@@ -490,7 +566,17 @@ export interface AuthApiInterface {
      * @throws {RequiredError}
      * @memberof AuthApiInterface
      */
-    postUsers(login?: Login, options?: AxiosRequestConfig): AxiosPromise<void>;
+    postAuthSignup(login?: Login, options?: AxiosRequestConfig): AxiosPromise<void>;
+
+    /**
+     * 
+     * @summary Update User Password
+     * @param {Password} [password] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AuthApiInterface
+     */
+    putAuthPassword(password?: Password, options?: AxiosRequestConfig): AxiosPromise<void>;
 
 }
 
@@ -554,8 +640,20 @@ export class AuthApi extends BaseAPI implements AuthApiInterface {
      * @throws {RequiredError}
      * @memberof AuthApi
      */
-    public postUsers(login?: Login, options?: AxiosRequestConfig) {
-        return AuthApiFp(this.configuration).postUsers(login, options).then((request) => request(this.axios, this.basePath));
+    public postAuthSignup(login?: Login, options?: AxiosRequestConfig) {
+        return AuthApiFp(this.configuration).postAuthSignup(login, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Update User Password
+     * @param {Password} [password] 
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof AuthApi
+     */
+    public putAuthPassword(password?: Password, options?: AxiosRequestConfig) {
+        return AuthApiFp(this.configuration).putAuthPassword(password, options).then((request) => request(this.axios, this.basePath));
     }
 }
 

--- a/src/components/model/SecuritySetting.tsx
+++ b/src/components/model/SecuritySetting.tsx
@@ -1,18 +1,104 @@
-import { Stack, Typography, Divider, TextField, Button } from '@mui/material';
+import { Visibility, VisibilityOff } from '@mui/icons-material';
+import { Stack, Typography, Divider, TextField, Button, IconButton } from '@mui/material';
+import * as React from 'react';
+import { AuthApi, Password } from '../../api/generated/api';
 
-const SecuritySetting = () => (
+const SecuritySetting = () => {
+  const [currentPassword, setOldPassword] = React.useState<string | null>(null);
+  const [newPassword, setNewPassword] = React.useState<string | null>(null);
+  const [confirmPassword, setConfirmPassword] = React.useState<string | null>(null);
+  const [showCurrentPassword, setShowCurrentPassword] = React.useState(false);
+  const [showNewPassword, setShowNewPassword] = React.useState(false);
+  const [showConfirmPassword, setShowConfirmPassword] = React.useState(false);
+  const authApi = new AuthApi();
+
+  const changePassword = async () => {
+    if (!currentPassword || !newPassword || !confirmPassword || newPassword !== confirmPassword) {
+      alert('正しく入力してください');
+      return;
+    }
+    const data: Password = {
+      old_password: currentPassword,
+      new_password: newPassword,
+    }
+    try {
+      await authApi.putAuthPassword(data, { withCredentials: true });
+    } catch (e) {
+      alert('パスワードの更新に失敗しました');
+    }
+  }
+
+  return (
     <Stack bgcolor="background.paper" width={500}>
       <Stack padding={2} direction="column" spacing={1}>
         <Typography variant="h4">Security</Typography>
         <Divider />
         <Typography variant="h5">Change password</Typography>
         <Typography variant="h6">Current password</Typography>
-        <TextField size="small" variant="outlined" value="current password" />
+        <TextField
+          size="small"
+          variant="outlined"
+          label="current password"
+          value={currentPassword}
+          onChange={e => setOldPassword(e.target.value)}
+          type={showCurrentPassword ? 'text' : 'password'}
+          InputProps={{
+            endAdornment: (
+              <IconButton
+                aria-label="toggle password visibility"
+                onClick={() => setShowCurrentPassword(!showCurrentPassword)}
+                edge="end"
+              >
+                {showCurrentPassword ? <VisibilityOff /> : <Visibility />}
+              </IconButton>
+            ),
+          }}
+        />
         <Typography variant="h6">New password</Typography>
-        <TextField size="small" variant="outlined" value="new password" />
+        <TextField
+          size="small"
+          variant="outlined"
+          label="new password"
+          value={newPassword}
+          onChange={e => setNewPassword(e.target.value)}
+          type={showNewPassword ? 'text' : 'password'}
+          InputProps={{
+            endAdornment: (
+              <IconButton
+                aria-label="toggle password visibility"
+                onClick={() => setShowNewPassword(!showNewPassword)}
+                edge="end"
+              >
+                {showNewPassword ? <VisibilityOff /> : <Visibility />}
+              </IconButton>
+            ),
+          }}
+        />
         <Typography variant="h6">Confirm password</Typography>
-        <TextField size="small" variant="outlined" value="confirm password" />
-        <Button variant="contained" color="primary">
+        <TextField
+          size="small"
+          variant="outlined"
+          label="confirm password"
+          value={confirmPassword}
+          onChange={e => setConfirmPassword(e.target.value)}
+          type={showConfirmPassword ? 'text' : 'password'}
+          InputProps={{
+            endAdornment: (
+              <IconButton
+                aria-label="toggle password visibility"
+                onClick={() => setShowConfirmPassword(!showConfirmPassword)}
+                edge="end"
+              >
+                {showConfirmPassword ? <VisibilityOff /> : <Visibility />}
+              </IconButton>
+            ),
+          }}
+        />
+        <Button
+          variant="contained"
+          color="primary"
+          onClick={changePassword}
+        >
           update password
         </Button>
         <Divider />
@@ -27,5 +113,6 @@ const SecuritySetting = () => (
       </Stack>
     </Stack>
   );
+};
 
 export default SecuritySetting;

--- a/src/components/model/SecuritySetting.tsx
+++ b/src/components/model/SecuritySetting.tsx
@@ -4,9 +4,9 @@ import * as React from 'react';
 import { AuthApi, Password } from '../../api/generated/api';
 
 const SecuritySetting = () => {
-  const [currentPassword, setOldPassword] = React.useState<string | null>(null);
-  const [newPassword, setNewPassword] = React.useState<string | null>(null);
-  const [confirmPassword, setConfirmPassword] = React.useState<string | null>(null);
+  const [currentPassword, setOldPassword] = React.useState<string>('');
+  const [newPassword, setNewPassword] = React.useState<string>('');
+  const [confirmPassword, setConfirmPassword] = React.useState<string>('');
   const [showCurrentPassword, setShowCurrentPassword] = React.useState(false);
   const [showNewPassword, setShowNewPassword] = React.useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = React.useState(false);

--- a/src/components/pages/SignUp.tsx
+++ b/src/components/pages/SignUp.tsx
@@ -56,7 +56,7 @@ const SignUp = () => {
     };
 
     await authApi
-      .postUsers(payload, { withCredentials: true })
+      .postAuthSignup(payload, { withCredentials: true })
       .then(async () => {
         await login();
         goHome();

--- a/src/components/pages/SignUp.tsx
+++ b/src/components/pages/SignUp.tsx
@@ -8,6 +8,7 @@ import { useNavigate } from 'react-router-dom';
 import { useContext, useEffect } from 'react';
 import { IconButton } from '@mui/material';
 import { Visibility, VisibilityOff } from '@mui/icons-material';
+import { useSnackbar } from 'notistack';
 import { AuthApi } from '../../api/generated/api';
 import { AuthContext } from '../../contexts/AuthContext';
 
@@ -28,6 +29,7 @@ const SignUp = () => {
   const navigate = useNavigate();
   const authApi = new AuthApi();
   const { authUser, login } = useContext(AuthContext);
+  const { enqueueSnackbar } = useSnackbar();
 
   const handleChange =
     (prop: keyof State) => (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -41,11 +43,19 @@ const SignUp = () => {
     });
   };
 
-  const handleErrorOccured = () => {
+  const handleErrorOccurred = () => {
     setValues({
       ...values,
       error: true,
     });
+  };
+
+  const goHome = () => {
+    navigate('/home');
+  };
+
+  const handleClick = () => {
+    navigate('/signin');
   };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -55,28 +65,18 @@ const SignUp = () => {
       password: values.password,
     };
 
-    await authApi
-      .postAuthSignup(payload, { withCredentials: true })
-      .then(async () => {
-        await login();
-        goHome();
-      })
-      .catch((err) => {
-        console.log(err);
-        handleErrorOccured();
-      });
+    try {
+      await authApi.postAuthSignup(payload, { withCredentials: true })
+      await login();
+      goHome();
+    } catch (err: any) {
+      enqueueSnackbar(err.response.data.message, { variant: 'error' });
+      handleErrorOccurred();
+    }
   };
 
   const handleOauthLogin = () => {
     window.location.href = String(process.env.REACT_APP_OAUTH_LOGIN_URL);
-  };
-
-  const goHome = () => {
-    navigate('/home');
-  };
-
-  const handleClick = () => {
-    navigate('/signin');
   };
 
   useEffect(() => {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import './index.css';
 import { BrowserRouter } from 'react-router-dom';
+import { SnackbarProvider } from 'notistack';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
 import { AuthProvider } from './contexts/AuthContext';
@@ -9,9 +10,17 @@ import { AuthProvider } from './contexts/AuthContext';
 ReactDOM.render(
   <React.StrictMode>
     <BrowserRouter>
-      <AuthProvider>
-        <App />
-      </AuthProvider>
+      <SnackbarProvider
+        anchorOrigin={{
+          vertical: 'top',
+          horizontal: 'right',
+        }}
+        autoHideDuration={2000}
+      >
+        <AuthProvider>
+          <App />
+        </AuthProvider>
+      </SnackbarProvider>
     </BrowserRouter>
   </React.StrictMode>,
   document.getElementById('root'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3136,7 +3136,7 @@ cliui@^7.0.2:
     strip-ansi "^6.0.0"
     wrap-ansi "^7.0.0"
 
-clsx@^1.1.1:
+clsx@^1.1.0, clsx@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/clsx/-/clsx-1.1.1.tgz#98b3134f9abbdf23b2663491ace13c5c03a73188"
   integrity sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==
@@ -4890,7 +4890,7 @@ history@^5.2.0:
   dependencies:
     "@babel/runtime" "^7.7.6"
 
-hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
+hoist-non-react-statics@^3.3.0, hoist-non-react-statics@^3.3.1, hoist-non-react-statics@^3.3.2:
   version "3.3.2"
   resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
   integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
@@ -6354,6 +6354,14 @@ normalize-url@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
+
+notistack@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/notistack/-/notistack-2.0.3.tgz#9007550e5cbc14df84d1d54e7a55ac0948eb59e8"
+  integrity sha512-krmVFtTO9kEY1Pa4NrbyexrjiRcV6TqBM2xLx8nuDea1g96Z/OZfkvVLmYKkTvoSJ3jyQntWK16z86ssW5kt4A==
+  dependencies:
+    clsx "^1.1.0"
+    hoist-non-react-statics "^3.3.0"
 
 npm-run-path@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
## チケットへのリンク
fix #47 
## やったこと
パスワード更新の機能を追加しました
## やらないこと

## テスト
1. 設定画面からセキュリティに遷移する
2. バリデーションの確認
    1. フォームのいずれかを空にした状態で更新するとアラートが表示される
    2. `new password`と`confirm password`が一致しない場合にアラートが表示される
3. パスワード更新処理の確認
    1. `current password`が間違えていた場合にアラートが表示される
    2. 正しいパスワードを入力し、更新処理を成功させる
    3. 一度ログアウトし、更新したパスワードでログインできることを確認する

## その他
https://github.com/RIFT-tokyo/transcendence-api/pull/47