### PR TITLE
グローバルメニューを追加

### DIFF
--- a/src/components/config/constants.ts
+++ b/src/components/config/constants.ts
@@ -1,0 +1,4 @@
+export const HOME_URL = '/home';
+export const CHAT_URL = '/chat';
+export const GAME_URL = '/pong';
+export const SETTING_URL = '/settings';

--- a/src/components/config/global-menu.tsx
+++ b/src/components/config/global-menu.tsx
@@ -1,0 +1,30 @@
+import SettingsIcon from '@mui/icons-material/Settings';
+import ChatIcon from '@mui/icons-material/Chat';
+import HomeIcon from '@mui/icons-material/Home';
+import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
+import { CHAT_URL, GAME_URL, HOME_URL, SETTING_URL } from './constants';
+
+const GlobalMenuItems = [
+  {
+    icon: <HomeIcon />,
+    text: 'Home',
+    to: HOME_URL,
+  },
+  {
+    icon: <ChatIcon />,
+    text: 'Chat',
+    to: CHAT_URL,
+  },
+  {
+    icon: <SportsEsportsIcon />,
+    text: 'Games',
+    to: GAME_URL,
+  },
+  {
+    icon: <SettingsIcon />,
+    text: 'Setting',
+    to: SETTING_URL
+  },
+];
+
+export default GlobalMenuItems;

--- a/src/components/ui/AppBarWithMenu.tsx
+++ b/src/components/ui/AppBarWithMenu.tsx
@@ -6,6 +6,7 @@ import {
   Box,
   Menu,
   MenuItem,
+  CssBaseline,
 } from '@mui/material';
 import * as React from 'react';
 import MenuIcon from '@mui/icons-material/Menu';
@@ -13,10 +14,12 @@ import { AccountCircle } from '@mui/icons-material';
 import { Outlet, useNavigate } from 'react-router-dom';
 import { AuthApi } from '../../api/generated/api';
 import { AuthContext } from '../../contexts/AuthContext';
+import GlobalMenu from './GlobalMenu';
 
 const AppBarWithMenu = () => {
   const { logout } = React.useContext(AuthContext);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
+  const [openDrawer, setOpenDrawer] = React.useState(false);
   const navigate = useNavigate();
   const authApi = new AuthApi();
 
@@ -51,10 +54,24 @@ const AppBarWithMenu = () => {
       });
   };
 
+  const toggleDrawer =
+    (open: boolean) =>
+    (event: React.KeyboardEvent | React.MouseEvent) => {
+      if (
+        event.type === 'keydown' &&
+        ((event as React.KeyboardEvent).key === 'Tab' ||
+          (event as React.KeyboardEvent).key === 'Shift')
+      ) {
+        return;
+      }
+      setOpenDrawer(open);
+    };
+
   return (
     <div>
-      <Box sx={{ flexGrow: 1, pt: 10 }}>
-        <AppBar>
+      <Box sx={{ pt: 8 }}>
+        <CssBaseline />
+        <AppBar sx={{ zIndex: (theme) => theme.zIndex.drawer + 1 }}>
           <Toolbar>
             <IconButton
               size="large"
@@ -62,6 +79,7 @@ const AppBarWithMenu = () => {
               color="inherit"
               aria-label="menu"
               sx={{ mr: 2 }}
+              onClick={toggleDrawer(!openDrawer)}
             >
               <MenuIcon />
             </IconButton>
@@ -109,6 +127,7 @@ const AppBarWithMenu = () => {
             </div>
           </Toolbar>
         </AppBar>
+        <GlobalMenu open={openDrawer} onClose={toggleDrawer(false)} />
       </Box>
       <Outlet />
     </div>

--- a/src/components/ui/GlobalMenu.tsx
+++ b/src/components/ui/GlobalMenu.tsx
@@ -1,0 +1,81 @@
+import { Box, Drawer, List, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom';
+import SettingsIcon from '@mui/icons-material/Settings';
+import ChatIcon from '@mui/icons-material/Chat';
+import HomeIcon from '@mui/icons-material/Home';
+import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
+
+type Props = {
+  open: boolean;
+  // eslint-disable-next-line no-unused-vars
+  onClose: (event: React.KeyboardEvent | React.MouseEvent) => void;
+}
+
+const DRAWER_WIDTH = 240;
+
+const GlobalMenuItems = [
+  {
+    icon: <HomeIcon />,
+    text: 'Home',
+    to: '/',
+  },
+  {
+    icon: <ChatIcon />,
+    text: 'Chat',
+    to: '/chat',
+  },
+  {
+    icon: <SportsEsportsIcon />,
+    text: 'Games',
+    to: '/pong',
+  },
+  {
+    icon: <SettingsIcon />,
+    text: 'Setting',
+    to: '/settings'
+  },
+]
+
+const GlobalMenu: React.VFC<Props> = ({ open, onClose }: Props) => {
+  const navigate = useNavigate();
+
+  return (
+    <Drawer
+      open={open}
+      onClose={onClose}
+      sx={{
+        width: DRAWER_WIDTH,
+        flexShrink: 0,
+        [`& .MuiDrawer-paper`]: { width: DRAWER_WIDTH, boxSizing: 'border-box' },
+      }}
+    >
+      <Box
+        sx={{
+          overflow: 'auto',
+          pt: 7,
+        }}
+        role="presentation"
+        onClick={onClose}
+        onKeyDown={onClose}
+      >
+        <List>
+          {GlobalMenuItems.map((item) => (
+            <ListItemButton
+              key={item.text}
+              onClick={() => navigate(item.to)}
+            >
+              <ListItemIcon>
+                {item.icon}
+              </ListItemIcon>
+              <ListItemText primary={item.text} />
+            </ListItemButton>
+          ))}
+        </List>
+      </Box>
+    </Drawer>
+  )
+}
+
+
+export default GlobalMenu;

--- a/src/components/ui/GlobalMenu.tsx
+++ b/src/components/ui/GlobalMenu.tsx
@@ -1,10 +1,7 @@
 import { Box, Drawer, List, ListItemButton, ListItemIcon, ListItemText } from '@mui/material';
 import * as React from 'react';
 import { useNavigate } from 'react-router-dom';
-import SettingsIcon from '@mui/icons-material/Settings';
-import ChatIcon from '@mui/icons-material/Chat';
-import HomeIcon from '@mui/icons-material/Home';
-import SportsEsportsIcon from '@mui/icons-material/SportsEsports';
+import GlobalMenuItems from '../config/global-menu';
 
 type Props = {
   open: boolean;
@@ -13,29 +10,6 @@ type Props = {
 }
 
 const DRAWER_WIDTH = 240;
-
-const GlobalMenuItems = [
-  {
-    icon: <HomeIcon />,
-    text: 'Home',
-    to: '/',
-  },
-  {
-    icon: <ChatIcon />,
-    text: 'Chat',
-    to: '/chat',
-  },
-  {
-    icon: <SportsEsportsIcon />,
-    text: 'Games',
-    to: '/pong',
-  },
-  {
-    icon: <SettingsIcon />,
-    text: 'Setting',
-    to: '/settings'
-  },
-]
 
 const GlobalMenu: React.VFC<Props> = ({ open, onClose }: Props) => {
   const navigate = useNavigate();


### PR DESCRIPTION
## チケットへのリンク
fix #53 
## やったこと
グローバルメニューを追加しました。
AppBar左端のハンバーガーメニューボタンのクリックで表示・非表示を切り替え可能です。
## やらないこと

## テスト
- メニューの表示・非表示の切り替え
- ボタンのクリックで対象のページに遷移することを確認

## その他
configにある程度本プロジェクト由来の内容を集めました。
他のコンポーネントに含まれるものなどもこれ以降のプルリクに含めながら修正していけるといいかな。
