### PR TITLE
footerの縦幅を狭くする

### DIFF
--- a/src/components/config/constants.ts
+++ b/src/components/config/constants.ts
@@ -18,3 +18,10 @@ export const EVENT = {
 };
 
 export const FT_COLOR = '#00BABC';
+
+const APPBAR_HEIGHT = 64;
+export const FOOTER_HEIGHT = 72;
+export const CONTENT_WITH_FOOTER_HEIGHT = `calc(100vh - ${APPBAR_HEIGHT}px)`;
+export const CONTENT_HEIGHT = `calc(100vh - ${
+  APPBAR_HEIGHT + FOOTER_HEIGHT
+}px)`;

--- a/src/components/config/constants.ts
+++ b/src/components/config/constants.ts
@@ -20,7 +20,7 @@ export const EVENT = {
 export const FT_COLOR = '#00BABC';
 
 const APPBAR_HEIGHT = 64;
-export const FOOTER_HEIGHT = 72;
+export const FOOTER_HEIGHT = 40;
 export const CONTENT_WITH_FOOTER_HEIGHT = `calc(100vh - ${APPBAR_HEIGHT}px)`;
 export const CONTENT_HEIGHT = `calc(100vh - ${
   APPBAR_HEIGHT + FOOTER_HEIGHT

--- a/src/components/ui/AppBarWithMenu.tsx
+++ b/src/components/ui/AppBarWithMenu.tsx
@@ -15,7 +15,11 @@ import { useSnackbar } from 'notistack';
 import { AuthApi } from '../../api/generated/api';
 import { AuthContext } from '../../contexts/AuthContext';
 import GlobalMenu from './GlobalMenu';
-import { SETTING_URL } from '../config/constants';
+import {
+  CONTENT_HEIGHT,
+  CONTENT_WITH_FOOTER_HEIGHT,
+  SETTING_URL,
+} from '../config/constants';
 import GlobalFooter from './GlobalFooter';
 import { SocketContext } from '../../contexts/SocketContext';
 
@@ -142,10 +146,10 @@ const AppBarWithMenu = () => {
       <GlobalMenu open={openDrawer} onClose={toggleDrawer(false)} />
       <Box
         component="div"
-        height="calc(100vh - 64px)"
+        height={CONTENT_WITH_FOOTER_HEIGHT}
         sx={{ mt: 8, overflowY: 'auto' }}
       >
-        <Box component="div" minHeight="calc(100vh - 136px)">
+        <Box component="div" minHeight={CONTENT_HEIGHT}>
           <RequiredAuth />
         </Box>
         <GlobalFooter />

--- a/src/components/ui/GlobalFooter.tsx
+++ b/src/components/ui/GlobalFooter.tsx
@@ -5,17 +5,11 @@ import Link from '@mui/material/Link';
 import { FOOTER_HEIGHT } from '../config/constants';
 
 const GlobalFooter: React.VFC = () => (
-  <Box component="footer" height={FOOTER_HEIGHT}>
-    <Typography
-      variant="h6"
-      align="center"
-      gutterBottom
-      sx={{
-        fontFamily: 'Zen Tokyo Zoo',
-      }}
-    >
-      TRANSCENDENCE
-    </Typography>
+  <Box
+    component="footer"
+    height={FOOTER_HEIGHT}
+    sx={{ display: 'flex', alignItems: 'center', justifyContent: 'center' }}
+  >
     <Typography
       variant="body2"
       align="center"
@@ -25,14 +19,12 @@ const GlobalFooter: React.VFC = () => (
       {'App icon by '}
       <Link color="inherit" href="https://icons8.com">
         icons8
-      </Link>{' '}
-    </Typography>
-    <Typography variant="body2" color="text.secondary" align="center">
-      {'Copyright © '}
+      </Link>
+      {', © '}
+      {new Date().getFullYear()}{' '}
       <Link color="inherit" href="https://github.com/RIFT-tokyo">
         RIFT Tokyo
       </Link>{' '}
-      {new Date().getFullYear()}.
     </Typography>
   </Box>
 );

--- a/src/components/ui/GlobalFooter.tsx
+++ b/src/components/ui/GlobalFooter.tsx
@@ -2,9 +2,10 @@ import * as React from 'react';
 import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Link from '@mui/material/Link';
+import { FOOTER_HEIGHT } from '../config/constants';
 
 const GlobalFooter: React.VFC = () => (
-  <Box component="footer" height={72}>
+  <Box component="footer" height={FOOTER_HEIGHT}>
     <Typography
       variant="h6"
       align="center"


### PR DESCRIPTION
## チケットへのリンク
fix #68 
## やったこと
- GlobalFooter
  - 縦幅を72pxから40pxにしました
  - ロゴを削除し、3行ではなく1行にテキストをまとめました
- constants
  - calcを使用している箇所で、constants.tsの定数を使用するようにしました

## やらないこと
特になし

## テスト
各種ページ（Home, Chat, Game, Setting）でfooterの表示が崩れていないことを確認済みです。

## その他
- 一旦 https://github.com/RIFT-tokyo/transcendence-front/issues/68#issuecomment-1120101022 の案を取り入れました。改善点があったらぜひ教えて下さい
- スクショ： https://github.com/RIFT-tokyo/transcendence-front/issues/68#issuecomment-1120150246 の1枚目の画像